### PR TITLE
Adding more fields to "members" database

### DIFF
--- a/client/src/pages/MemberPage.jsx
+++ b/client/src/pages/MemberPage.jsx
@@ -49,6 +49,8 @@ const Register = () => {
   const handleNewMember = async () => {
     const member = {
       username: userData.username,
+      name: userData.name,
+      email: userData.email,
     };
     await axios.post('/api/members', member);
   };
@@ -190,12 +192,17 @@ const ElectionCard = ({ election }) => {
 const Renew = () => {
   const { userData } = useContext(UserDataContext);
 
+  const nameAndEmail = {
+    name: userData.name,
+    email: userData.email,
+  };
+
   return (
     <div style={{ margin: '2rem 20vw', textAlign: 'center' }}>
-      <Button
-        onClick={() => {
-          axios.put(`/api/members/${userData.username}`);
-        }}
+        <Button
+          onClick={() => {
+            axios.put(`/api/members/${userData.username}`, nameAndEmail);
+          }}
       >
         RENOVAR
       </Button>

--- a/client/src/pages/MemberPage.jsx
+++ b/client/src/pages/MemberPage.jsx
@@ -51,6 +51,7 @@ const Register = () => {
       username: userData.username,
       name: userData.name,
       email: userData.email,
+      courses: userData.courses,
     };
     await axios.post('/api/members', member)
       .then((res) => { if (res) window.location.reload(); });
@@ -193,16 +194,17 @@ const ElectionCard = ({ election }) => {
 const Renew = () => {
   const { userData } = useContext(UserDataContext);
 
-  const nameAndEmail = {
+  const nameEmailCourses = {
     name: userData.name,
     email: userData.email,
+    courses: userData.courses,
   };
 
   return (
     <div style={{ margin: '2rem 20vw', textAlign: 'center' }}>
         <Button
           onClick={() => {
-            axios.put(`/api/members/${userData.username}`, nameAndEmail)
+            axios.put(`/api/members/${userData.username}`, nameEmailCourses)
               .then((res) => { if (res) window.location.reload(); });
           }}
       >

--- a/client/src/pages/MemberPage.jsx
+++ b/client/src/pages/MemberPage.jsx
@@ -52,7 +52,8 @@ const Register = () => {
       name: userData.name,
       email: userData.email,
     };
-    await axios.post('/api/members', member);
+    await axios.post('/api/members', member)
+      .then((res) => { if (res) window.location.reload(); });
   };
 
   return (
@@ -201,7 +202,8 @@ const Renew = () => {
     <div style={{ margin: '2rem 20vw', textAlign: 'center' }}>
         <Button
           onClick={() => {
-            axios.put(`/api/members/${userData.username}`, nameAndEmail);
+            axios.put(`/api/members/${userData.username}`, nameAndEmail)
+              .then((res) => { if (res) window.location.reload(); });
           }}
       >
         RENOVAR

--- a/server/database/membersDatabase.js
+++ b/server/database/membersDatabase.js
@@ -4,9 +4,13 @@ const createMembers = async () => {
   try {
     await db.query(
       `CREATE TABLE members(
-                username varchar(10) PRIMARY KEY,
+                "username" varchar(10) PRIMARY KEY,
+                "name" varchar(255),
+                "email" varchar(255),
                 "registerDate" date,
-                "canVoteDate" date
+                "canVoteDate" date,
+                "renewStartDate" date,
+                "renewEndDate" date
             )`,
     );
   } catch (err) {
@@ -17,7 +21,15 @@ const createMembers = async () => {
 
 const createMember = async (member) => {
   try {
-    await db.query('INSERT INTO members VALUES($1, $2, $3)', [member.username, member.registerDate, member.canVoteDate]);
+    await db.query("INSERT INTO members VALUES($1, $2, $3, $4, $5, $6, $7)", [
+      member.username,
+      member.name,
+      member.email,
+      member.registerDate,
+      member.canVoteDate,
+      member.renewStartDate,
+      member.renewEndDate,
+    ]);
   } catch (err) {
     console.error(err);
   }
@@ -25,7 +37,18 @@ const createMember = async (member) => {
 
 const updateMember = async (member) => {
   try {
-    await db.query('UPDATE members SET "registerDate" = $1, "canVoteDate" = $2 WHERE username = $3', [member.registerDate, member.canVoteDate, member.username]);
+    await db.query(
+      'UPDATE members SET "name" = $1, "email" = $2, "registerDate" = $3::date, "canVoteDate" = $4::date, "renewStartDate" = $5::date, "renewEndDate" = $6::date WHERE "username" = $7',
+      [
+        member.name,
+        member.email,
+        member.registerDate,
+        member.canVoteDate,
+        member.renewStartDate,
+        member.renewEndDate,
+        member.username,
+      ]
+    );
   } catch (err) {
     console.error(err);
   }
@@ -34,7 +57,10 @@ const updateMember = async (member) => {
 const getMember = async (username) => {
   let member;
   try {
-    const memberResult = await db.query('SELECT * FROM members WHERE username = $1', [username]);
+    const memberResult = await db.query(
+      'SELECT * FROM members WHERE "username" = $1',
+      [username]
+    );
     [member] = memberResult.rows;
   } catch (err) {
     console.error(err);

--- a/server/database/membersDatabase.js
+++ b/server/database/membersDatabase.js
@@ -7,6 +7,7 @@ const createMembers = async () => {
                 "username" varchar(10) PRIMARY KEY,
                 "name" varchar(255),
                 "email" varchar(255),
+                "courses" varchar(33),
                 "registerDate" date,
                 "canVoteDate" date,
                 "renewStartDate" date,
@@ -21,10 +22,11 @@ const createMembers = async () => {
 
 const createMember = async (member) => {
   try {
-    await db.query("INSERT INTO members VALUES($1, $2, $3, $4, $5, $6, $7)", [
+    await db.query("INSERT INTO members VALUES($1, $2, $3, $4, $5, $6, $7, $8)", [
       member.username,
       member.name,
       member.email,
+      member.courses,
       member.registerDate,
       member.canVoteDate,
       member.renewStartDate,
@@ -38,10 +40,11 @@ const createMember = async (member) => {
 const updateMember = async (member) => {
   try {
     await db.query(
-      'UPDATE members SET "name" = $1, "email" = $2, "registerDate" = $3::date, "canVoteDate" = $4::date, "renewStartDate" = $5::date, "renewEndDate" = $6::date WHERE "username" = $7',
+      'UPDATE members SET "name" = $1, "email" = $2, "courses" = $3, "registerDate" = $4::date, "canVoteDate" = $5::date, "renewStartDate" = $6::date, "renewEndDate" = $7::date WHERE "username" = $8',
       [
         member.name,
         member.email,
+        member.courses,
         member.registerDate,
         member.canVoteDate,
         member.renewStartDate,

--- a/server/routes/membersRoute.js
+++ b/server/routes/membersRoute.js
@@ -5,9 +5,10 @@ const router = express.Router();
 
 router.use(express.json());
 
-router.post('/', async (req) => {
+router.post('/', async (req, res) => {
   const member = req.body;
   await membersService.registerMember(member);
+  res.json(member.username);
 });
 
 router.get('/:username', async (req, res) => {
@@ -16,10 +17,11 @@ router.get('/:username', async (req, res) => {
   res.json(member);
 });
 
-router.put('/:username', async (req) => {
+router.put('/:username', async (req,res) => {
   const { username } = req.params;
   const nameAndEmail = req.body;
   await membersService.renovateMember(username, nameAndEmail);
+  res.json(username);
 });
 
 module.exports = router;

--- a/server/routes/membersRoute.js
+++ b/server/routes/membersRoute.js
@@ -19,8 +19,8 @@ router.get('/:username', async (req, res) => {
 
 router.put('/:username', async (req,res) => {
   const { username } = req.params;
-  const nameAndEmail = req.body;
-  await membersService.renovateMember(username, nameAndEmail);
+  const nameEmailCourses = req.body;
+  await membersService.renovateMember(username, nameEmailCourses);
   res.json(username);
 });
 

--- a/server/routes/membersRoute.js
+++ b/server/routes/membersRoute.js
@@ -18,7 +18,8 @@ router.get('/:username', async (req, res) => {
 
 router.put('/:username', async (req) => {
   const { username } = req.params;
-  await membersService.renovateMember(username);
+  const nameAndEmail = req.body;
+  await membersService.renovateMember(username, nameAndEmail);
 });
 
 module.exports = router;

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -52,14 +52,27 @@ const isAdmin = (username) => {
   return adminUsernames.includes(username);
 };
 
+const getAcronyms = (data) => {
+  var acronyms = [];
+  data.roles.forEach((role) => {
+    if (role.type === "STUDENT")
+      role.registrations.forEach((registration) =>
+        acronyms.push(registration.acronym)
+      );
+  });
+  return acronyms.join();
+}; 
+
 const getUserData = async (accessToken) => {
   const personInformation = await getPersonInformation(accessToken);
+  const acronyms = getAcronyms(personInformation);
 
   const userData = {
     username: personInformation.username,
+    displayName: personInformation.displayName,
     name: personInformation.name,
     email: personInformation.institutionalEmail,
-    displayName: personInformation.displayName,
+    courses: acronyms,
     isActiveTecnicoStudent: isActiveTecnicoStudent(personInformation.roles),
     isActiveLMeicStudent: isActiveLMeicStudent(personInformation.roles),
     isAdmin: isAdmin(personInformation.username),

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -57,6 +57,8 @@ const getUserData = async (accessToken) => {
 
   const userData = {
     username: personInformation.username,
+    name: personInformation.name,
+    email: personInformation.institutionalEmail,
     displayName: personInformation.displayName,
     isActiveTecnicoStudent: isActiveTecnicoStudent(personInformation.roles),
     isActiveLMeicStudent: isActiveLMeicStudent(personInformation.roles),

--- a/server/services/membersService.js
+++ b/server/services/membersService.js
@@ -11,28 +11,26 @@ const addMonthsToDate = (numMonths, date) => {
   return newDate;
 };
 
-const isMemberExpired = async (username) => {
-  const member = await membersDatabase.getMember(username);
-  const expirationDate = addMonthsToDate(validPeriod, member.registerDate);
-  const currDate = new Date();
-  return currDate >= expirationDate;
+const canMemberVote = async (currDate, member) => {
+  return currDate >= member.canVoteDate;
 };
 
-const canMemberVote = async (username) => {
-  const member = await membersDatabase.getMember(username);
-  const currDate = new Date();
-  return currDate >= member.canVoteDate;
+const isMemberExpired = async (currDate, member) => {
+  return currDate >= member.renewStartDate;
 };
 
 const getMember = async (username) => {
   const memberInformation = await membersDatabase.getMember(username);
   if (!memberInformation) return null;
+  const currDate = new Date();
 
-  const isExpired = await isMemberExpired(memberInformation.username);
-  const canVote = await canMemberVote(memberInformation.username);
+  const isExpired = await isMemberExpired(currDate, memberInformation);
+  const canVote = await canMemberVote(currDate, memberInformation);
 
   const member = {
     username: memberInformation.username,
+    name: memberInformation.name,
+    email: memberInformation.email,
     isExpired,
     canVote,
   };
@@ -43,24 +41,42 @@ const getMember = async (username) => {
 const registerMember = async (member) => {
   const currDate = new Date();
   const canVoteDate = addMonthsToDate(waitingPeriod, currDate);
+  const renewStartDate = addMonthsToDate(validPeriod, currDate);
+  const renewEndDate = addMonthsToDate(validPeriod + gracePeriod, currDate);
 
   const newMember = member;
   newMember.registerDate = currDate;
   newMember.canVoteDate = canVoteDate;
+  newMember.renewStartDate = renewStartDate;
+  newMember.renewEndDate = renewEndDate;
 
   membersDatabase.createMember(newMember);
 };
 
-const renovateMember = async (username) => {
+const renovateMember = async (username, nameAndEmail) => {
   const member = await membersDatabase.getMember(username);
   const currDate = new Date();
+  const gracePeriodExpired = currDate >= member.renewEndDate;
 
-  const gracePeriodExpirationDate = addMonthsToDate(validPeriod + gracePeriod, member.registerDate);
-  const gracePeriodExpired = (currDate >= gracePeriodExpirationDate);
-  const canVoteDate = (gracePeriodExpired ? addMonthsToDate(waitingPeriod, currDate) : currDate);
+  // name/email changed in fenix OR if we don't have record of name/email
+  const name =
+    nameAndEmail.name != member.name ? nameAndEmail.name : member.name;
+  const email =
+    nameAndEmail.email != member.email ? nameAndEmail.email : member.email;
 
+  const canVoteDate = gracePeriodExpired
+    ? addMonthsToDate(waitingPeriod, currDate)
+    : currDate;
+  const renewStartDate = addMonthsToDate(validPeriod, currDate);
+  const renewEndDate = addMonthsToDate(validPeriod + gracePeriod, currDate);
+
+  member.name = name;
+  member.email = email;
   member.registerDate = currDate;
   member.canVoteDate = canVoteDate;
+  member.renewStartDate = renewStartDate;
+  member.renewEndDate = renewEndDate;
+
   membersDatabase.updateMember(member);
 };
 

--- a/server/services/membersService.js
+++ b/server/services/membersService.js
@@ -31,6 +31,7 @@ const getMember = async (username) => {
     username: memberInformation.username,
     name: memberInformation.name,
     email: memberInformation.email,
+    courses: memberInformation.courses,
     isExpired,
     canVote,
   };
@@ -53,16 +54,18 @@ const registerMember = async (member) => {
   membersDatabase.createMember(newMember);
 };
 
-const renovateMember = async (username, nameAndEmail) => {
+const renovateMember = async (username, nameEmailCourses) => {
   const member = await membersDatabase.getMember(username);
   const currDate = new Date();
   const gracePeriodExpired = currDate >= member.renewEndDate;
 
-  // name/email changed in fenix OR if we don't have record of name/email
+  // changed in fenix OR if column in database = null
   const name =
-    nameAndEmail.name != member.name ? nameAndEmail.name : member.name;
+    nameEmailCourses.name != member.name ? nameEmailCourses.name : member.name;
   const email =
-    nameAndEmail.email != member.email ? nameAndEmail.email : member.email;
+    nameEmailCourses.email != member.email ? nameEmailCourses.email : member.email;
+  const courses =
+    nameEmailCourses.courses != member.courses ? nameEmailCourses.courses : member.courses;
 
   const canVoteDate = gracePeriodExpired
     ? addMonthsToDate(waitingPeriod, currDate)
@@ -72,6 +75,7 @@ const renovateMember = async (username, nameAndEmail) => {
 
   member.name = name;
   member.email = email;
+  member.courses = courses;
   member.registerDate = currDate;
   member.canVoteDate = canVoteDate;
   member.renewStartDate = renewStartDate;


### PR DESCRIPTION
The members database only stores 3 elements: `username`, `registerDate` and `canVoteDate`.
Every year we need to communicate with our members to summon general meeting, and with current fields, we can't identify them and we can't get their contact information.

The code implemented adds the fields `name`, and `email` to fix the issue. The fields `renewStartDate` and `renewEndDate` were also added to alleviate computational work (every time you getMember(), you had to make some calculations). The field `courses` is for the courses that the student is studying in Tecnico.

>⚠To remind: **in production**, the data in "members" table needs to be stored and changed manually, since the code of members database altered the structure.