### PR TITLE
fixing "Old elections show up as active"

### DIFF
--- a/client/src/pages/AdminElectionsPage.jsx
+++ b/client/src/pages/AdminElectionsPage.jsx
@@ -18,7 +18,7 @@ const ViewElections = () => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    fetch('/api/elections')
+    fetch(`/api/admin/elections`)
       .then((res) => res.json())
       .then(
         (res) => {
@@ -45,9 +45,7 @@ const ViewElections = () => {
     return (
       <div style={{ margin: '2rem 20vw 1rem 20vw' }}>
         <h1 style={{ textAlign: 'center', margin: 0 }}>
-          {elections.length}
-          {' '}
-          Eleições Ativas
+          Todas as eleições ({elections.length})
         </h1>
         <div
           style={{
@@ -68,6 +66,10 @@ const ViewElections = () => {
   return <div>Não foi possível carregar as eleições.</div>;
 };
 
+const currDate = new Date();
+const active = (election) => 
+  currDate>=new Date(election.startDate) && currDate<=new Date(election.endDate);
+
 const ElectionCard = ({ election }) => {
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
@@ -81,6 +83,9 @@ const ElectionCard = ({ election }) => {
       >
         <Card.Body>
           <Card.Title>{election.name}</Card.Title>
+          <h4 style={{color:'darkblue'}}>
+            {active(election) && "ATIVA"}
+          </h4>
         </Card.Body>
       </Card>
       <ElectionModal
@@ -96,6 +101,9 @@ const ElectionModal = ({ election, show, handleClose }) => (
   <Modal size="lg" show={show} onHide={handleClose} centered>
     <Modal.Header closeButton>
       <Modal.Title>{election.name}</Modal.Title>
+      <h4 style={{color:'darkblue', right: '45px', position: 'absolute'}}>
+        {active(election) && "ATIVA"}
+      </h4>
     </Modal.Header>
     <Modal.Body>
       <h4>ID</h4>

--- a/server/database/electionsDatabase.js
+++ b/server/database/electionsDatabase.js
@@ -100,7 +100,23 @@ const getOptions = async (electionId) => {
   return optionsVotes;
 };
 
-const getElections = async () => {
+const getActiveElections = async (currDate) => {
+  let electionsOptions;
+  try {
+    const electionsResult = await db.query('SELECT * FROM elections WHERE $1 BETWEEN "startDate" AND "endDate" ', [currDate]);
+    const elections = electionsResult.rows;
+    electionsOptions = await Promise.all(elections.map(async (election) => {
+      const electionOptions = election;
+      electionOptions.options = await getOptions(election.id);
+      return electionOptions;
+    }));
+  } catch (err) {
+    console.error(err);
+  }
+  return electionsOptions;
+};
+
+const getAllElections = async () => {
   let electionsOptions;
   try {
     const electionsResult = await db.query('SELECT * FROM elections');
@@ -129,6 +145,7 @@ module.exports = {
   createOptions,
   createVotes,
   createElection,
-  getElections,
+  getActiveElections,
+  getAllElections,
   createVote,
 };

--- a/server/routes/adminElectionsRoute.js
+++ b/server/routes/adminElectionsRoute.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { electionsService } = require('../services');
+
+const router = express.Router();
+
+router.use(express.json());
+
+router.get('/', async (req, res) => {
+  const elections = await electionsService.getAllElections();
+  res.json(elections);
+});
+
+module.exports = router;

--- a/server/routes/electionsRoute.js
+++ b/server/routes/electionsRoute.js
@@ -11,7 +11,7 @@ router.post('/', async (req) => {
 });
 
 router.get('/', async (req, res) => {
-  const elections = await electionsService.getElections();
+  const elections = await electionsService.getActiveElections();
   res.json(elections);
 });
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,4 +1,5 @@
 const authRoute = require('./authRoute');
+const adminElectionsRoute = require('./adminElectionsRoute');
 const areasRoute = require('./areasRoute');
 const thesesRoute = require('./thesesRoute');
 const membersRoute = require('./membersRoute');
@@ -6,6 +7,7 @@ const electionsRoute = require('./electionsRoute');
 
 module.exports = {
   authRoute,
+  adminElectionsRoute,
   areasRoute,
   thesesRoute,
   membersRoute,

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const morgan = require('morgan');
 const { databaseSchema } = require('./database');
 
 const {
-  authRoute, areasRoute, thesesRoute, membersRoute, electionsRoute,
+  authRoute, areasRoute, thesesRoute, membersRoute, electionsRoute, adminElectionsRoute
 } = require('./routes');
 
 const app = express();
@@ -21,6 +21,7 @@ app.use(express.static(path.join(__dirname, '../client/build')));
 app.use('/api/auth', authRoute);
 app.use('/api/areas', areasRoute);
 app.use('/api/theses', thesesRoute);
+app.use('/api/admin/elections', adminElectionsRoute);
 app.use('/api/members', membersRoute);
 app.use('/api/elections', electionsRoute);
 

--- a/server/services/electionsService.js
+++ b/server/services/electionsService.js
@@ -4,8 +4,14 @@ const newElection = async (election) => {
   await electionsDatabase.createElection(election);
 };
 
-const getElections = async () => {
-  const elections = await electionsDatabase.getElections();
+const getActiveElections = async () => {
+  const currDate = new Date();
+  const elections = await electionsDatabase.getActiveElections(currDate);
+  return elections;
+};
+
+const getAllElections = async () => {
+  const elections = await electionsDatabase.getAllElections();
   return elections;
 };
 
@@ -15,6 +21,7 @@ const newVote = async (id, vote) => {
 
 module.exports = {
   newElection,
-  getElections,
+  getActiveElections,
+  getAllElections,
   newVote,
 };


### PR DESCRIPTION
The database for the request of 'api/elections' will only give the active elections (changed the query of elections table).
Admin view ('api/admin/elections') shows all elections in the database and identifies the active ones.

This fixes and closes #105. Feel free to give feedback!