### PR TITLE
GAC Dashboard - Backend

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,8 @@ import AdminAreasPage from './pages/AdminAreasPage';
 import AdminThesesPage from './pages/AdminThesesPage';
 import AdminElectionsPage from './pages/AdminElectionsPage';
 
+import GacPage from './pages/GacPage';
+
 import UserDataContext from './UserDataContext';
 
 import './App.css';
@@ -138,6 +140,10 @@ const App = () => {
               <AdminElectionsPage />
             </AdminRoute>
 
+            <GacRoute path="/mag">
+              <GacPage />
+            </GacRoute>
+
             <Route path="/*">
               <Redirect to="/" />
             </Route>
@@ -174,6 +180,19 @@ const ActiveLMeicStudentRoute = ({ exact, path, children }) => {
   }
   return null;
 };
+
+const GacRoute = ({ exact, path, children }) => {
+  const { userData } = useContext(UserDataContext);
+
+  if (userData && userData.isGacMember) {
+    return (
+      <Route exact={exact} path={path}>
+        {children}
+      </Route>
+    );
+  }
+  return null;
+}
 
 const AdminRoute = ({ exact, path, children }) => {
   const { userData } = useContext(UserDataContext);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,8 +23,6 @@ import AdminAreasPage from './pages/AdminAreasPage';
 import AdminThesesPage from './pages/AdminThesesPage';
 import AdminElectionsPage from './pages/AdminElectionsPage';
 
-import GacPage from './pages/GacPage';
-
 import UserDataContext from './UserDataContext';
 
 import './App.css';
@@ -140,10 +138,6 @@ const App = () => {
               <AdminElectionsPage />
             </AdminRoute>
 
-            <GacRoute path="/mag">
-              <GacPage />
-            </GacRoute>
-
             <Route path="/*">
               <Redirect to="/" />
             </Route>
@@ -180,19 +174,6 @@ const ActiveLMeicStudentRoute = ({ exact, path, children }) => {
   }
   return null;
 };
-
-const GacRoute = ({ exact, path, children }) => {
-  const { userData } = useContext(UserDataContext);
-
-  if (userData && userData.isGacMember) {
-    return (
-      <Route exact={exact} path={path}>
-        {children}
-      </Route>
-    );
-  }
-  return null;
-}
 
 const AdminRoute = ({ exact, path, children }) => {
   const { userData } = useContext(UserDataContext);

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,4 +8,6 @@ PGHOST=
 PGPORT=
 PGDATABASE=
 
+# GAC = general assembly committee (MAG in PT)
+GAC_USERNAMES=
 ADMIN_USERNAMES=

--- a/server/database/membersDatabase.js
+++ b/server/database/membersDatabase.js
@@ -71,13 +71,14 @@ const getMember = async (username) => {
   return member;
 };
 
-const getActiveMembers = async (limitDate) => {
+const getActiveMembers = async (currDate, limitDate) => {
   let activeMembers;
   try {
     const activeMembersResult = await db.query(
-      'SELECT * FROM members WHERE "registerDate" > $1::date \
+      'SELECT * FROM members \
+        WHERE "registerDate" > $1::date AND "renewEndDate" > $2::date \
         ORDER BY length(username), username',
-      [limitDate]
+      [limitDate, currDate]
     );
     activeMembers = activeMembersResult.rows;
   } catch (err) {

--- a/server/database/membersDatabase.js
+++ b/server/database/membersDatabase.js
@@ -71,9 +71,39 @@ const getMember = async (username) => {
   return member;
 };
 
+const getActiveMembers = async (limitDate) => {
+  let activeMembers;
+  try {
+    const activeMembersResult = await db.query(
+      'SELECT * FROM members WHERE "registerDate" > $1::date \
+        ORDER BY length(username), username',
+      [limitDate]
+    );
+    activeMembers = activeMembersResult.rows;
+  } catch (err) {
+    console.error(err);
+  }
+  return activeMembers;
+};
+
+const getAllMembers = async () => {
+  let allMembers;
+  try {
+    const allMembersResult = await db.query(
+      'SELECT * FROM members ORDER BY length(username), username'
+    );
+    allMembers = allMembersResult.rows;
+  } catch (err) {
+    console.error(err);
+  }
+  return allMembers;
+};
+
 module.exports = {
   createMembers,
   createMember,
   updateMember,
   getMember,
+  getActiveMembers,
+  getAllMembers,
 };

--- a/server/routes/gacRoute.js
+++ b/server/routes/gacRoute.js
@@ -17,4 +17,10 @@ router.get('/:choice', async (req, res) => {
   res.json(members);
 });
 
+router.put('/delete/:username', async (req, res) => {
+  const { username } = req.params;
+  await membersService.removeMember(username);
+  res.json(username);
+});
+
 module.exports = router;

--- a/server/routes/gacRoute.js
+++ b/server/routes/gacRoute.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const { membersService } = require('../services');
+
+const router = express.Router();
+
+router.use(express.json());
+
+router.get('/:choice', async (req, res) => {
+  const { choice } = req.params;
+
+  const options = {
+    'active': membersService.getActiveMembers(),
+    'all': membersService.getAllMembers(),
+  }
+
+  const members = await options[choice];
+  res.json(members);
+});
+
+module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ const adminElectionsRoute = require('./adminElectionsRoute');
 const areasRoute = require('./areasRoute');
 const thesesRoute = require('./thesesRoute');
 const membersRoute = require('./membersRoute');
+const gacRoute = require('./gacRoute');
 const electionsRoute = require('./electionsRoute');
 
 module.exports = {
@@ -11,5 +12,6 @@ module.exports = {
   areasRoute,
   thesesRoute,
   membersRoute,
+  gacRoute,
   electionsRoute,
 };

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const morgan = require('morgan');
 const { databaseSchema } = require('./database');
 
 const {
-  authRoute, areasRoute, thesesRoute, membersRoute, electionsRoute, adminElectionsRoute
+  authRoute, areasRoute, thesesRoute, membersRoute, electionsRoute, adminElectionsRoute, gacRoute
 } = require('./routes');
 
 const app = express();
@@ -23,6 +23,7 @@ app.use('/api/areas', areasRoute);
 app.use('/api/theses', thesesRoute);
 app.use('/api/admin/elections', adminElectionsRoute);
 app.use('/api/members', membersRoute);
+app.use('/api/mag', gacRoute);
 app.use('/api/elections', electionsRoute);
 
 app.get('/*', function(req, res) {

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -47,6 +47,12 @@ const isActiveLMeicStudent = (roles) => {
   return roles.some((role) => role.type === 'STUDENT' && role.registrations.some((registration) => LMeicAcronyms.includes(registration.acronym)));
 };
 
+const isGacMember = (username) => {
+  // GAC = general assembly committee (MAG in PT)
+  const gacUsernames = process.env.GAC_USERNAMES.split(',');
+  return gacUsernames.includes(username);
+};
+
 const isAdmin = (username) => {
   const adminUsernames = process.env.ADMIN_USERNAMES.split(',');
   return adminUsernames.includes(username);
@@ -75,6 +81,7 @@ const getUserData = async (accessToken) => {
     courses: acronyms,
     isActiveTecnicoStudent: isActiveTecnicoStudent(personInformation.roles),
     isActiveLMeicStudent: isActiveLMeicStudent(personInformation.roles),
+    isGacMember: isGacMember(personInformation.username),
     isAdmin: isAdmin(personInformation.username),
   };
 

--- a/server/services/membersService.js
+++ b/server/services/membersService.js
@@ -3,9 +3,21 @@ const { membersDatabase } = require('../database');
 const waitingPeriod = 4;
 const validPeriod = 12;
 const gracePeriod = 6;
+const dateColumns = ['registerDate', 'canVoteDate', 'renewStartDate', 'renewEndDate'];
+
+/* Dates */
+const formatDate = (date) => 
+  new Date(date).toLocaleDateString('pt-pt').split(',')[0];
 
 const addMonthsToDate = (numMonths, date) => {
   const newMonth = date.getMonth() + numMonths;
+  const newDate = new Date(date);
+  newDate.setMonth(newMonth);
+  return newDate;
+};
+
+const subMonthsToDate = (numMonths, date) => {
+  const newMonth = date.getMonth() - numMonths;
   const newDate = new Date(date);
   newDate.setMonth(newMonth);
   return newDate;
@@ -21,7 +33,7 @@ const hastoRenew = (currDate, member) =>
 const isMemberExpired = (currDate, member) =>
   currDate > member.renewEndDate;
 
-const getStatus = (currDate, member) => {
+const getStatus = (member, currDate = new Date()) => {
   const canVote = canMemberVote(currDate, member);
   const renew = hastoRenew(currDate, member);
   const expired = isMemberExpired(currDate, member);
@@ -37,10 +49,39 @@ const getMember = async (username) => {
   const memberInfo = await membersDatabase.getMember(username);
   if (!memberInfo) return null;
 
-  const currDate = new Date();
-  memberInfo.status = getStatus(currDate, memberInfo);
+  memberInfo.status = getStatus(memberInfo);
+  dateColumns.forEach( (date) => memberInfo[date] = formatDate(memberInfo[date]) );
 
   return memberInfo;
+};
+
+const getActiveMembers = async () => {
+  const currDate = new Date();
+  const limitDate = subMonthsToDate(validPeriod + gracePeriod, currDate);
+
+  var activeMembers = await membersDatabase.getActiveMembers(limitDate);
+  if (!activeMembers) return null;
+  
+  activeMembers
+    .forEach( member => {
+      member.status = getStatus(member);
+      dateColumns.forEach((date) => member[date] = formatDate(member[date]));
+    });
+
+  return activeMembers;
+};
+
+const getAllMembers = async () => {
+  var allMembers = await membersDatabase.getAllMembers();
+  if (!allMembers) return null;
+  
+  allMembers
+    .forEach( member => {
+      member.status = getStatus(member);
+      dateColumns.forEach((date) => member[date] = formatDate(member[date]));
+    });
+
+  return allMembers;
 };
 
 const registerMember = async (member) => {
@@ -91,6 +132,8 @@ const renovateMember = async (username, nameEmailCourses) => {
 
 module.exports = {
   getMember,
+  getActiveMembers,
+  getAllMembers,
   registerMember,
   renovateMember,
 };

--- a/server/services/membersService.js
+++ b/server/services/membersService.js
@@ -59,7 +59,7 @@ const getActiveMembers = async () => {
   const currDate = new Date();
   const limitDate = subMonthsToDate(validPeriod + gracePeriod, currDate);
 
-  var activeMembers = await membersDatabase.getActiveMembers(limitDate);
+  var activeMembers = await membersDatabase.getActiveMembers(currDate, limitDate);
   if (!activeMembers) return null;
   
   activeMembers
@@ -130,10 +130,22 @@ const renovateMember = async (username, nameEmailCourses) => {
   membersDatabase.updateMember(member);
 };
 
+const removeMember = async (username) => {
+  //Removing a member is the same as renewDate being equal to today
+  const memberInfo = await membersDatabase.getMember(username);
+  const currDate = new Date();
+
+  memberInfo.renewStartDate = currDate;
+  memberInfo.renewEndDate = currDate;
+
+  membersDatabase.updateMember(memberInfo);
+};
+
 module.exports = {
   getMember,
   getActiveMembers,
   getAllMembers,
   registerMember,
   renovateMember,
+  removeMember,
 };


### PR DESCRIPTION
We have been talking about implementing a page so that General Assembly Committee (GAC, or MAG in PT) can visualize active members and their information, to actively do their job, like remembering members to renovate their status, or even to get the emails to set a meeting.

This is the backend of the implementation I'm developing.
> ⚠️ In production ambient, please remember to set the gacMembers in .env. 