### PR TITLE
Change Loading Divs to react-bootstrap/Spinner

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import Layout from './components/Layout';
+import LoadSpinner from "./hooks/loadSpinner";
 
 import HomePage from './pages/HomePage';
 import ActivitiesPage from './pages/ActivitiesPage';
@@ -81,7 +82,7 @@ const App = () => {
   }, []);
 
   if (!isLoaded) {
-    return <div>...</div>;
+    return <LoadSpinner />;
   }
 
   if (urlParams.has('error')) {

--- a/client/src/hooks/loadSpinner.jsx
+++ b/client/src/hooks/loadSpinner.jsx
@@ -1,0 +1,18 @@
+import Spinner from 'react-bootstrap/Spinner';
+
+const firstColor  = { color: "#2863fd" }
+const secondColor = { color: "#248be3" }
+const thirdColor  = { color: "#35d1fa" }
+const fourthColor = { color: "#5ee8fa" }
+
+const LoadSpinner = () => (
+  <div style={{ textAlign:'center', paddingTop:'25px' }}>
+    <Spinner animation="grow" style={firstColor}  />
+    <Spinner animation="grow" style={secondColor} />
+    <Spinner animation="grow" style={thirdColor}  />
+    <Spinner animation="grow" style={fourthColor} />
+    <span className="visually-hidden">Loading...</span>
+  </div>
+);
+
+export default LoadSpinner;

--- a/client/src/pages/AdminAreasPage.jsx
+++ b/client/src/pages/AdminAreasPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import LoadSpinner from "../hooks/loadSpinner";
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Card from 'react-bootstrap/Card';
@@ -33,7 +34,7 @@ const ViewAreas = () => {
   }, []);
 
   if (!isLoaded) {
-    return <div>...</div>;
+    return <LoadSpinner />;
   }
   if (error) {
     return (

--- a/client/src/pages/AdminElectionsPage.jsx
+++ b/client/src/pages/AdminElectionsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import LoadSpinner from "../hooks/loadSpinner";
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Card from 'react-bootstrap/Card';
@@ -32,7 +33,7 @@ const ViewElections = () => {
       );
   }, []);
 
-  if (!isLoaded) return <div>...</div>;
+  if (!isLoaded) return <LoadSpinner />;
   if (error) {
     return (
       <div>

--- a/client/src/pages/AdminThesesPage.jsx
+++ b/client/src/pages/AdminThesesPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import LoadSpinner from "../hooks/loadSpinner";
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Card from 'react-bootstrap/Card';
@@ -50,7 +51,7 @@ const ViewTheses = () => {
       </div>
     );
   }
-  return <div>...</div>;
+  return <LoadSpinner />;
 };
 
 const ThesisCard = ({ thesis, areas }) => {

--- a/client/src/pages/GacPage.jsx
+++ b/client/src/pages/GacPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import useWindowSize from "../hooks/useWindowSize";
+import LoadSpinner from "../hooks/loadSpinner";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 import Form from 'react-bootstrap/Form';
@@ -66,7 +67,7 @@ const ActiveMembersPage = ({ keySelected }) => {
 
   return (
     <>
-      {!isLoaded && <div>...</div>}
+      {!isLoaded && <LoadSpinner />}
       {error && (
         <div>
           Erro:
@@ -129,7 +130,7 @@ const AllMembersPage = ({ keySelected }) => {
 
   return (
     <>
-      {!isLoaded && <div>...</div>}
+      {!isLoaded && <LoadSpinner />}
       {error && (
         <div>
           Erro:
@@ -212,7 +213,7 @@ const CreateMoreInfoModal = ({ show, handleClose, username }) => {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {!isLoaded && <div>Loading...</div>}
+          {!isLoaded && <LoadSpinner />}
           {error && <div>Error: {error}</div>}
           {member !== null && isLoaded && (
             <div className={style.infoCard}>

--- a/client/src/pages/MemberPage.jsx
+++ b/client/src/pages/MemberPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
+import LoadSpinner from "../hooks/loadSpinner";
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Form from 'react-bootstrap/Form';
@@ -32,7 +33,7 @@ const MembersPage = () => {
 
   return (
     <div className={style.principalBody}>
-      {(!isLoaded) && "..."}
+      {(!isLoaded) && <LoadSpinner />}
       {(error) && 
         <div>
           Erro:
@@ -156,7 +157,7 @@ const Vote = () => {
       );
   }, []);
 
-  if (!isLoaded) return <div>...</div>;
+  if (!isLoaded) return <LoadSpinner />;
   if (error) {
     return (
       <div>

--- a/client/src/pages/ThesisMasterPage.jsx
+++ b/client/src/pages/ThesisMasterPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-
+import LoadSpinner from "../hooks/loadSpinner";
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import ToggleButton from 'react-bootstrap/ToggleButton';
 import Modal from 'react-bootstrap/Modal';
@@ -45,7 +45,7 @@ const Areas = ({
 
   const handleChange = (area) => setCheckedAreas(area);
 
-  if (!isLoaded) return <div>...</div>;
+  if (!isLoaded) return <LoadSpinner />;
   if (error) {
     return (
       <div>
@@ -116,7 +116,7 @@ const Theses = ({ areas, checkedAreas }) => {
       );
   }, []);
 
-  if (!isLoaded) return <div>...</div>;
+  if (!isLoaded) return <LoadSpinner />;
   if (error) {
     return (
       <div>


### PR DESCRIPTION
This PR is purely visual and does what the title implies.
I have modified the pages so whenever there is a load section, it has been replaced with [Spinners](https://react-bootstrap.github.io/components/spinners/), namely 4 Spinners with the corresponding colors of the new logo.

It looks like the gif below:
![NEIIST](https://user-images.githubusercontent.com/48919500/189460454-4eee2e1f-29ba-4829-b5fe-25fae6e2623b.gif)
