### PR TITLE
Highlight Team Coordinators in the About Us Page

### DIFF
--- a/client/src/components/aboutPage/CollabCard.jsx
+++ b/client/src/components/aboutPage/CollabCard.jsx
@@ -7,33 +7,20 @@ const DivPersonCard = ({ name, job, image, teams }) => {
 
   return (
     <div className={style.cardContainer}>
-      {isCoordinator ? (
-        <CoordinatorCard name={name} job={job} src={image} />
-      ) : (
-        <PersonCard name={name} job={job} src={image} />
-      )}
+      <PersonCard name={name} job={job} src={image} isCoordinator={isCoordinator} />
     </div>
   );
 };
 
-const PersonCard = ({ name, job, src }) => (
+const PersonCard = ({ name, job, src, isCoordinator }) => (
   <Card className={`${style.card}`}>
     <Card.Img className={`${style.cardImg} hover-zoom hover-shadow`} variant="top" src={src} />
     <Card.ImgOverlay className={style.cardImgOver}>
+      {isCoordinator && (
+        <div className={style.coordinatorCard}>Coordenador(a)</div>
+      )}
       <Card.Title bsPrefix={style.cardTitle}>{name}</Card.Title>
       {job && <Card.Text bsPrefix={style.cardText}>{job}</Card.Text>}
-    </Card.ImgOverlay>
-  </Card>
-);
-
-const CoordinatorCard = ({ name, job, src }) => (
-  <Card className={`${style.card} ${style.card}`}>
-    <Card.Img className={`${style.cardImg} hover-zoom hover-shadow`} variant="top" src={src} />
-    <Card.ImgOverlay className={style.cardImgOver}>
-      <Card.Title bsPrefix={style.cardTitle}>{name}</Card.Title>
-      <div className={style.coordinatorCard}>Coordenador(a)</div>
-      {job && <Card.Text bsPrefix={style.cardText}>{job}</Card.Text>}
-
     </Card.ImgOverlay>
   </Card>
 );

--- a/client/src/components/aboutPage/CollabCard.jsx
+++ b/client/src/components/aboutPage/CollabCard.jsx
@@ -27,12 +27,13 @@ const PersonCard = ({ name, job, src }) => (
 );
 
 const CoordinatorCard = ({ name, job, src }) => (
-  <Card className={`${style.card} ${style.coordinatorCard}`}>
+  <Card className={`${style.card} ${style.card}`}>
     <Card.Img className={`${style.cardImg} hover-zoom hover-shadow`} variant="top" src={src} />
     <Card.ImgOverlay className={style.cardImgOver}>
       <Card.Title bsPrefix={style.cardTitle}>{name}</Card.Title>
+      <div className={style.coordinatorCard}>Coordenador(a)</div>
       {job && <Card.Text bsPrefix={style.cardText}>{job}</Card.Text>}
-      <div className={style.coordinatorBadge}>Coordenador(a)</div>
+
     </Card.ImgOverlay>
   </Card>
 );

--- a/client/src/components/aboutPage/CollabCard.jsx
+++ b/client/src/components/aboutPage/CollabCard.jsx
@@ -1,11 +1,20 @@
 import { Card } from 'react-bootstrap';
-import style from '../../pages/css/AboutPage.module.css'
+import style from '../../pages/css/AboutPage.module.css';
 
-const DivPersonCard = ({ name, job, image }) => (
-  <div className={style.cardContainer}>
-    <PersonCard name={name} job={job} src={image}/>
-  </div>
-);
+const DivPersonCard = ({ name, job, image, teams }) => {
+  console.log("teams -> ", teams);
+  const isCoordinator = teams?.includes('COOR-');
+
+  return (
+    <div className={style.cardContainer}>
+      {isCoordinator ? (
+        <CoordinatorCard name={name} job={job} src={image} />
+      ) : (
+        <PersonCard name={name} job={job} src={image} />
+      )}
+    </div>
+  );
+};
 
 const PersonCard = ({ name, job, src }) => (
   <Card className={`${style.card}`}>
@@ -13,6 +22,17 @@ const PersonCard = ({ name, job, src }) => (
     <Card.ImgOverlay className={style.cardImgOver}>
       <Card.Title bsPrefix={style.cardTitle}>{name}</Card.Title>
       {job && <Card.Text bsPrefix={style.cardText}>{job}</Card.Text>}
+    </Card.ImgOverlay>
+  </Card>
+);
+
+const CoordinatorCard = ({ name, job, src }) => (
+  <Card className={`${style.card} ${style.coordinatorCard}`}>
+    <Card.Img className={`${style.cardImg} hover-zoom hover-shadow`} variant="top" src={src} />
+    <Card.ImgOverlay className={style.cardImgOver}>
+      <Card.Title bsPrefix={style.cardTitle}>{name}</Card.Title>
+      {job && <Card.Text bsPrefix={style.cardText}>{job}</Card.Text>}
+      <div className={style.coordinatorBadge}>Coordenador(a)</div>
     </Card.ImgOverlay>
   </Card>
 );

--- a/client/src/components/aboutPage/TeamModal.jsx
+++ b/client/src/components/aboutPage/TeamModal.jsx
@@ -42,6 +42,7 @@ const ActiveMembersDiv = ({ activeTeamMembers }) => (
           key={index}
           name={`${member.name.split(' ')[0]}\n${member.name.split(' ')[1]}`}
           image={getCollabImage(member.name)}
+          teams={member.teams}
         />
       ))}
     </div>

--- a/client/src/pages/AboutPage.jsx
+++ b/client/src/pages/AboutPage.jsx
@@ -13,7 +13,7 @@ import "./../App.css";
 import style from "./css/AboutPage.module.css";
 import collabs from "../images/colaboradores/collaborators.json";
 import { normalizeJob } from "../components/functions/dataTreatment.jsx";
-import { fetchCollabsResume } from "../Api.service.js";
+import { fetchCollabsResume, fetchAllCollabs } from "../Api.service.js";
 
 const lectiveYear = collabs.anoLetivo;
 
@@ -27,6 +27,17 @@ const AboutPage = () => {
       .then((res) => {
         setActiveMembers(res);
       });
+
+    // TODO - Remove this
+    fetchAllCollabs()
+      .then((res) => {
+        console.log("All Collaborators:", res);
+      })
+      .catch((err) => {
+        console.error("Error fetching all collaborators:", err);
+      });
+
+      
   }, []);
 
   return (
@@ -35,7 +46,6 @@ const AboutPage = () => {
         <HeaderDiv activeMembersLength={activeMembers?.length} />
         <OurTeamsDiv activeMembers={activeMembers} />
       </div>
-
       {Object.entries(collabs.orgaosSociais).map(
         ([socialEntity, members], index) => (
           <SocialEntityDiv
@@ -56,6 +66,7 @@ const AboutPage = () => {
 };
 
 const ActiveMembersDiv = ({ activeMembers }) => (
+  console.log("Active Members:", activeMembers),
   <div className={style.allMembersDiv}>
     <h2>{`Membros Ativos ${lectiveYear}`}</h2>
     <div className={style.allMembersCard}>
@@ -64,6 +75,7 @@ const ActiveMembersDiv = ({ activeMembers }) => (
           key={index}
           name={`${member.name.split(" ")[0]}\n${member.name.split(" ")[1]}`}
           image={getCollabImage(member.name)}
+          teams={member.teams}
         />
       ))}
     </div>

--- a/client/src/pages/AboutPage.jsx
+++ b/client/src/pages/AboutPage.jsx
@@ -26,18 +26,7 @@ const AboutPage = () => {
       .catch((err) => setActiveMembersError(err))
       .then((res) => {
         setActiveMembers(res);
-      });
-
-    // TODO - Remove this
-    fetchAllCollabs()
-      .then((res) => {
-        console.log("All Collaborators:", res);
-      })
-      .catch((err) => {
-        console.error("Error fetching all collaborators:", err);
-      });
-
-      
+      });  
   }, []);
 
   return (
@@ -75,7 +64,6 @@ const ActiveMembersDiv = ({ activeMembers }) => (
           key={index}
           name={`${member.name.split(" ")[0]}\n${member.name.split(" ")[1]}`}
           image={getCollabImage(member.name)}
-          teams={member.teams}
         />
       ))}
     </div>

--- a/client/src/pages/AboutPage.jsx
+++ b/client/src/pages/AboutPage.jsx
@@ -13,7 +13,7 @@ import "./../App.css";
 import style from "./css/AboutPage.module.css";
 import collabs from "../images/colaboradores/collaborators.json";
 import { normalizeJob } from "../components/functions/dataTreatment.jsx";
-import { fetchCollabsResume, fetchAllCollabs } from "../Api.service.js";
+import { fetchCollabsResume } from "../Api.service.js";
 
 const lectiveYear = collabs.anoLetivo;
 
@@ -55,7 +55,6 @@ const AboutPage = () => {
 };
 
 const ActiveMembersDiv = ({ activeMembers }) => (
-  console.log("Active Members:", activeMembers),
   <div className={style.allMembersDiv}>
     <h2>{`Membros Ativos ${lectiveYear}`}</h2>
     <div className={style.allMembersCard}>

--- a/client/src/pages/css/AboutPage.module.css
+++ b/client/src/pages/css/AboutPage.module.css
@@ -220,15 +220,15 @@
 }
 
 .coordinatorCard {
-  position: absolute;
-  background-color: rgba(0, 0, 0, 0.3);
+  position: flex;
+  background-color: rgba(0, 0, 0, 0.6);
+  opacity: 0.85;
   color: white;
   font-weight: bold;
   font-size: 0.7rem;
-  padding: 0.1rem 0.5rem;
-  border-radius: 9px;
-  top: 1em;
-  right: 1.7em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
 }
 
 @media only screen and (min-width: 1225px) {

--- a/client/src/pages/css/AboutPage.module.css
+++ b/client/src/pages/css/AboutPage.module.css
@@ -179,22 +179,6 @@
   margin: .5em 2em;
 }
 
-.coordinatorCard {
-  border: 2px solid rgb(112, 112, 110);
-  box-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
-}
-
-.coordinatorBadge {
-  background-color: rgb(143, 143, 143);
-  color: rgb(255, 255, 255);
-  font-weight: bold;
-  padding: 0.2rem 0.5rem;
-  border-radius: 5px;
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
-
 .header h1,
 .allMembersDiv h2,
 .socialOrgansDiv h2 {
@@ -233,6 +217,18 @@
   align-items: center;
   justify-content: center;
   flex-wrap: nowrap;
+}
+
+.coordinatorCard {
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.3);
+  color: white;
+  font-weight: bold;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 9px;
+  top: 1em;
+  right: 1.7em;
 }
 
 @media only screen and (min-width: 1225px) {

--- a/client/src/pages/css/AboutPage.module.css
+++ b/client/src/pages/css/AboutPage.module.css
@@ -179,6 +179,22 @@
   margin: .5em 2em;
 }
 
+.coordinatorCard {
+  border: 2px solid rgb(112, 112, 110);
+  box-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+}
+
+.coordinatorBadge {
+  background-color: rgb(143, 143, 143);
+  color: rgb(255, 255, 255);
+  font-weight: bold;
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .header h1,
 .allMembersDiv h2,
 .socialOrgansDiv h2 {


### PR DESCRIPTION
Worked on feature: #419 

**Overview**: This feature visually identifies team coordinators when the TeamModal is displayed on the AboutPage.

**Implemented**:

- Each PersonCard now includes the teams that the user belongs to. If a team name contains the prefix "COOR-", indicating a coordinator role, a badge is displayed.

**Example**: Hypothetically, user 'João Costa' is coordinator of the Dev-Team:
![Screenshot from 2025-04-03 01-28-58](https://github.com/user-attachments/assets/010bf156-1537-4dae-8964-0848d42d6697)


