### PR TITLE
fix(CollabCard): multiple coordinators one team

### DIFF
--- a/client/src/components/aboutPage/CollabCard.jsx
+++ b/client/src/components/aboutPage/CollabCard.jsx
@@ -1,8 +1,8 @@
 import { Card } from 'react-bootstrap';
 import style from '../../pages/css/AboutPage.module.css';
 
-const DivPersonCard = ({ name, job, image, teams }) => {
-  const isCoordinator = teams?.includes('COOR-');
+const DivPersonCard = ({ name, job, image, teams, teamId }) => {
+  const isCoordinator = teams?.includes(`COOR-${teamId}`);
 
   return (
     <div className={style.cardContainer}>

--- a/client/src/components/aboutPage/TeamModal.jsx
+++ b/client/src/components/aboutPage/TeamModal.jsx
@@ -28,12 +28,12 @@ const CreateTeamModal = ({
       <hr />
       <ActiveMembersDiv
         activeTeamMembers={activeMembers?.filter((member) => member.teams.includes(teamId))}
+        teamId={teamId}
       />
     </Modal.Body>
   </Modal>
 );
-
-const ActiveMembersDiv = ({ activeTeamMembers }) => (
+const ActiveMembersDiv = ({ activeTeamMembers, teamId }) => (
   <>
     <h4>Membros da Equipa ({activeTeamMembers.length ?? '0'})</h4>
     <div className={`${style.allMembersCard} ${style.activeTeamMembers}`}>
@@ -43,6 +43,7 @@ const ActiveMembersDiv = ({ activeTeamMembers }) => (
           name={`${member.name.split(' ')[0]}\n${member.name.split(' ')[1]}`}
           image={getCollabImage(member.name)}
           teams={member.teams}
+          teamId={teamId}
         />
       ))}
     </div>


### PR DESCRIPTION
Take the images below as an example in this case, Inês Costa is a member of the DEV-Team and also a Coordinator of the Visual-Team, Miguel Raposo is only the Coordinator of the DEV-Team.

![image](https://github.com/user-attachments/assets/3bb9b564-2e1f-4a42-9b26-60d53113bf2b)

![image2](https://github.com/user-attachments/assets/d71b0dab-0162-4422-b214-cb8b9e6305ea)


Technical details:
- teamId is passed to the CollabCard Component from TeamModal.
- CollabCard now checks if the team associated to the person in the database (table:collaborators, field:teams) is 
   COOR-(teamId).

Refs: neiist-dev#447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced team member cards on the About page now dynamically display coordinator status based on team-specific information.
  - Improved team modal functionality includes personalized member presentation by incorporating unique team data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->