### PR TITLE
Data automatic autofill with correct redirect

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -67,10 +67,18 @@ const App = () => {
     return userDataJson;
   };
 
-  const Redirect = (user) =>
-    window.location.replace(
-      user?.isCollab ? "/collab" : user?.isMember ? "/socios" : "/"
-    );
+  const Redirect = (user) => {
+    const autofillRedirect = localStorage.getItem("orderDetailsAutofill");
+  
+    if (autofillRedirect === "true") {
+      localStorage.removeItem("orderDetailsAutofill");
+      window.location.replace("/checkout");
+    } else {
+      window.location.replace(
+        user?.isCollab ? "/collab" : user?.isMember ? "/socios" : "/"
+      );
+    }
+  };
 
   useEffect(() => {
     async function auth() {

--- a/client/src/components/checkoutPage/OrderDetails.jsx
+++ b/client/src/components/checkoutPage/OrderDetails.jsx
@@ -5,8 +5,23 @@ import {
   Button,
   Tooltip,
 } from "react-bootstrap";
+import { useContext } from "react";
+import UserDataContext from "../../UserDataContext";
+import { useEffect } from "react";
 
 function OrderDetails({ formData, setFormData, errors }) {
+  const { userData } = useContext(UserDataContext);
+
+  const handleAutofill = () => {
+    localStorage.setItem("orderDetailsAutofill", "true");
+
+    const fenixLoginUrl =
+      "https://fenix.tecnico.ulisboa.pt/oauth/userdialog" +
+      `?client_id=${process.env.REACT_APP_FENIX_CLIENT_ID}` +
+      `&redirect_uri=${process.env.REACT_APP_FENIX_REDIRECT_URI}`;
+    window.location.href = fenixLoginUrl;
+  };
+
   const handleInputChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
@@ -22,10 +37,17 @@ function OrderDetails({ formData, setFormData, errors }) {
     </Tooltip>
   );
 
-  const fenixLoginUrl =
-    "https://fenix.tecnico.ulisboa.pt/oauth/userdialog" +
-    `?client_id=${process.env.REACT_APP_FENIX_CLIENT_ID}` +
-    `&redirect_uri=${process.env.REACT_APP_FENIX_REDIRECT_URI}`;
+  useEffect(() => {
+    if (userData && !formData.name && !formData.email && !formData.istId) {
+      setFormData((prev) => ({
+        ...prev,
+        name: userData.name || prev.name,
+        email: userData.email || prev.email,
+        istId: userData.username || prev.istId,
+        campus: userData.courses.includes("-A") ? "alameda" : "taguspark",
+      }));
+    }
+  }, [userData, formData, setFormData]);
 
   return (
     <Container className="p-4 bg-white rounded shadow-sm">
@@ -36,7 +58,7 @@ function OrderDetails({ formData, setFormData, errors }) {
           !formData.istId ||
           !formData.campus) && (
           <Button
-            href={fenixLoginUrl}
+            onClick={handleAutofill}
             variant="outline-primary"
             size="sm"
             className="d-flex align-items-center gap-2"


### PR DESCRIPTION
The existing data autofill feature on OrderDetails, now after a successful login with Fenix redirects the user back to the checkout page with its data already filled in.

### Changes:
* `Redirect` function in `App.jsx` to use a new `orderDetailsAutofill` flag in `localStorage`. This flag indicates if the user comes from the normal login button or the dedicated autofill flow.
* New `handleAutofill` function in `OrderDetails.jsx` used to set the `orderDetailsAutofill` flag and begin the auth process with Fenix.
* `useEffect` hook in `OrderDetails.jsx` to autofill the form fields (`name`, `email`, `istId`, and `campus`) with user data from the context if available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an autofill option for order details, allowing users to populate form fields automatically using their saved user data.
- **Improvements**
  - The autofill process now uses a button click instead of a direct link, providing a smoother user experience and redirecting users to the login page when needed.
  - Form fields are automatically populated with user information if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->